### PR TITLE
Configurable Exectution Strategies

### DIFF
--- a/graphql-router/src/main/java/com/networknt/graphql/router/ExecutionStrategyProvider.java
+++ b/graphql-router/src/main/java/com/networknt/graphql/router/ExecutionStrategyProvider.java
@@ -1,0 +1,28 @@
+package com.networknt.graphql.router;
+
+import graphql.execution.ExecutionStrategy;
+
+/**
+ * ExecutionStrategyProvider interface that is used to inject execution strategy
+ * implementations into the framework. The service module will pass these on to
+ * the graphql-java framework.
+ *
+ * @author Logi Ragnarsson
+ */
+public interface ExecutionStrategyProvider {
+
+    /**
+     * Return an execution strategy to use for queries or null to use the default.
+     */
+    ExecutionStrategy getQueryExecutionStrategy();
+
+    /**
+     * Return an execution strategy to use for mutations or null to use the default.
+     */
+    ExecutionStrategy getMutationExecutionStrategy();
+
+    /**
+     * Return an execution strategy to use for subscriptions or null to use the default.
+     */
+    ExecutionStrategy getSubscriptionExecutionStrategy();
+}

--- a/graphql-router/src/main/java/com/networknt/graphql/router/handlers/GraphqlPostHandler.java
+++ b/graphql-router/src/main/java/com/networknt/graphql/router/handlers/GraphqlPostHandler.java
@@ -58,11 +58,7 @@ public class GraphqlPostHandler implements HttpHandler {
         ExecutionStrategyProvider executionStrategyProvider = SingletonServiceFactory.getBean(ExecutionStrategyProvider.class);
         if(executionStrategyProvider != null) {
             queryExecutionStrategy = executionStrategyProvider.getQueryExecutionStrategy();
-        }
-        if(executionStrategyProvider != null) {
             mutationExecutionStrategy = executionStrategyProvider.getMutationExecutionStrategy();
-        }
-        if(executionStrategyProvider != null) {
             subscriptionExecutionStrategy = executionStrategyProvider.getSubscriptionExecutionStrategy();
         }
     }


### PR DESCRIPTION
Make it possible to override the 3 execution strategies used by GraphQL for Queries, Mutations and Subscriptions respectively in case the defaults are not suitable.