### PR TITLE
Trivial GraphqlEndpointSource listing `/graphql@{get,post,options}`…

### DIFF
--- a/graphql-router/src/main/java/com/networknt/graphql/router/GraphqlEndpointSource.java
+++ b/graphql-router/src/main/java/com/networknt/graphql/router/GraphqlEndpointSource.java
@@ -1,0 +1,28 @@
+package com.networknt.graphql.router;
+
+import com.networknt.graphql.common.GraphqlUtil;
+import com.networknt.handler.config.EndpointSource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Arrays;
+
+/**
+ * Lists standard GraphQl endpoints at /graphql and /subscriptions.
+ */
+public class GraphqlEndpointSource implements EndpointSource {
+
+    private static final Logger log = LoggerFactory.getLogger(GraphqlEndpointSource.class);
+
+    @Override
+    public Iterable<Endpoint> listEndpoints() {
+        String graphqlPath = GraphqlUtil.config.getPath();
+        if(log.isInfoEnabled()) log.info("Generating " + graphqlPath + " from graphql.yml");
+        return Arrays.asList(
+            new Endpoint(graphqlPath, "GET"),
+            new Endpoint(graphqlPath, "POST"),
+            new Endpoint(graphqlPath, "OPTIONS")
+            // The subscriptions websocket endpoint does not need to be listed
+        );
+    }
+}

--- a/graphql-router/src/main/java/com/networknt/graphql/router/GraphqlEndpointSource.java
+++ b/graphql-router/src/main/java/com/networknt/graphql/router/GraphqlEndpointSource.java
@@ -8,7 +8,7 @@ import org.slf4j.LoggerFactory;
 import java.util.Arrays;
 
 /**
- * Lists standard GraphQl endpoints at /graphql and /subscriptions.
+ * Lists standard GraphQl endpoints at /graphql (or as reconfigured in Graphql.config)
  */
 public class GraphqlEndpointSource implements EndpointSource {
 

--- a/graphql-router/src/test/java/com/networknt/graphql/router/GraphqlEndpointSourceTest.java
+++ b/graphql-router/src/test/java/com/networknt/graphql/router/GraphqlEndpointSourceTest.java
@@ -1,0 +1,37 @@
+package com.networknt.graphql.router;
+
+import com.networknt.handler.config.EndpointSource;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
+public class GraphqlEndpointSourceTest {
+
+    @Test
+    public void testPetstoreEndpoints() {
+        GraphqlEndpointSource source = new GraphqlEndpointSource();
+        Iterable<EndpointSource.Endpoint> endpoints = source.listEndpoints();
+
+        // Extract a set of string representations of endpoints
+        Set<String> endpointStrings = StreamSupport
+            .stream(endpoints.spliterator(), false)
+            .map(Object::toString)
+            .collect(Collectors.toSet());
+
+        // Assert that we got what we wanted
+        Assert.assertEquals(
+            new HashSet<>(Arrays.asList(
+                "/graphql@GET",
+                "/graphql@POST",
+                "/graphql@OPTIONS"
+            )),
+            endpointStrings
+        );
+    }
+
+}


### PR DESCRIPTION
… endpoints as configured in `graphql.yml` to match what the `GraphqlRouter` will set up.

Usage:
```yaml
paths:

# Standard GraphQL End-Points

- source: com.networknt.graphql.router.GraphqlEndpointSource
  exec:
  - common-chain
  - graphql-verify
  - audit
  - graphql-validator
  - graphql-handler
```

The following gets logged at startup (with default `graphql.yml`):
```
10:21:38.644 [main] is.thing.usernotes.0.0  INFO  com.networknt.config.Config getConfigStream - Config loaded from default folder for graphql.yml
10:21:38.649 [main] is.thing.usernotes.0.0  INFO  c.n.g.router.GraphqlEndpointSource listEndpoints - Generating /graphql from graphql.yml
```